### PR TITLE
Fix two bugs

### DIFF
--- a/coval/corefud/mention.py
+++ b/coval/corefud/mention.py
@@ -136,7 +136,7 @@ class Mention:
             return self.__lt__(other) or self.__eq__(other)
 
         def __str__(self):
-            return "{:d}-{:d}".format(self._sentord, self._wordord)
+            return f"{self._sentord}-{self._wordord}"
 
         def __repr__(self):
             return str(self)

--- a/coval/corefud/reader.py
+++ b/coval/corefud/reader.py
@@ -45,13 +45,14 @@ def split_data_to_docs(data):
     word2docid = {}
     docord = 0
     docid = None
+    doc_clusters = defaultdict(list)
     for tree in data.trees:
         if tree.newdoc:
             docord += 1
             docid = tree.newdoc if tree.newdoc is not True else docord
+            doc_clusters[docid] = defaultdict(list)
         for node in tree.descendants_and_empty:
             word2docid[node] = docid
-    doc_clusters = defaultdict(lambda: defaultdict(list))
 
     for cluster in data.coref_entities:
         mention_doc = None


### PR DESCRIPTION
Don't crash on non-integer `node.ord` and documents without mentions.